### PR TITLE
Fix for setting a 0 value

### DIFF
--- a/de.manumaticx.circularprogress/controllers/widget.js
+++ b/de.manumaticx.circularprogress/controllers/widget.js
@@ -145,8 +145,8 @@ function setValue(_value){
  * @param {Object} _args
  */
 function animate(_args){
-  var value = _args.value || 100;
-  var duration = _args.duration || 100;
+  var value = _args.value || 0;
+  var duration = _args.duration || 0;
   var angle = parseFloat(value / 100 * 360);
 
   // create the animation

--- a/de.manumaticx.circularprogress/controllers/widget.js
+++ b/de.manumaticx.circularprogress/controllers/widget.js
@@ -146,7 +146,7 @@ function setValue(_value){
  */
 function animate(_args){
   var value = _args.value || 0;
-  var duration = _args.duration || 0;
+  var duration = _args.duration || 100;
   var angle = parseFloat(value / 100 * 360);
 
   // create the animation

--- a/de.manumaticx.circularprogress/widget.json
+++ b/de.manumaticx.circularprogress/widget.json
@@ -3,7 +3,7 @@
 	"name": "Circular Progress",
 	"description" : "A Circular Progressbar",
 	"author": "Manuel Lehner (manumaticx@gmail.com)",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"copyright":"Copyright (c) 2014",
 	"license":"MIT",
 	"min-alloy-version": "1.3",


### PR DESCRIPTION
If you tried to animate to a 0 value, it would appear to be 100% instead. Fixed the default to be 0 for the animate() method.