### PR TITLE
Changed 'showText' method to 'setShowText'.

### DIFF
--- a/de.manumaticx.circularprogress/controllers/widget.js
+++ b/de.manumaticx.circularprogress/controllers/widget.js
@@ -179,7 +179,7 @@ function setProgressBackgroundColor(_color){
  * dynamically set the visibility of text
  * @param {Boolean} _flag
  */
-function showText(_flag){
+function setShowText(_flag){
     options.showText = !!_flag;
     updateUi();
 }
@@ -247,6 +247,6 @@ exports.setText = setText;
 exports.getText = getText;
 exports.setProgressColor = setProgressColor;
 exports.setProgressBackgroundColor = setProgressBackgroundColor;
-exports.showText = showText;
+exports.setShowText = setShowText;
 exports.hide = hide;
 exports.show = show;


### PR DESCRIPTION
There is an issue with the method showText(): it has the same name as the property 'showText' of the widget object. Since there are getters and setters definitions for every property, declaring
`exports.showText = showText;`
at the end of the widget overrides the value of the property with the definition of the method showText(). This causes a crash on Android.
Changing the name of the method solves the problem.